### PR TITLE
Added CRC8 install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,11 @@ https://github.com/SwiCago/HeatPump
 
 custom_components/climate/mitsubishi_mqtt.py
 
+## Needed python modules
+
+Make sure the CRC8 module is installed by running the following command on your homeassistant server: 
+pip install crc8
+
 ## Balboa Hot Tub
 
 Adds Balboa Hot Tub support. Copy the files from the directories into your homeassistant directory.


### PR DESCRIPTION
Testing on a fresh development install of homeassistant, I could not get the module to run before I had installed CRC 8